### PR TITLE
Create Pairs Selector control that can be used for Withdraw, Open Loan, Repay Loan

### DIFF
--- a/components/OpenLoan/OpenLoanView.tsx
+++ b/components/OpenLoan/OpenLoanView.tsx
@@ -166,11 +166,11 @@ const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: O
     return (
         <>
             <Container>
-                <Box m='auto' borderRadius={'2xl'} bg={'#1d2c52'} maxW='420px' boxShadow='dark-lg'>
+                <Box m='auto' borderRadius={'2xl'} bg={'#111827'} maxW='600px' boxShadow='dark-lg'>
                     <form onSubmit={handleSubmit(validateBeforeSubmit)}>
                         <FormControl p='10px 15px 0px 15px' boxShadow='lg'>
                             <VStack>
-                                <Heading color={'#e2e8f0'} marginBottom={'25px'}>Open Your Loan</Heading>
+                                <Heading color={'#e2e8f0'} fontSize={24} marginBottom={'25px'}>Open Your Loan</Heading>
                                 <PairsSelector token0={token0} token1={token1} setToken0={setToken0} setToken1={setToken1} />
                                 <Container textAlign='center'>
                                     <ButtonGroup variant='loanInfo' display='inline-block' size='tiny' >

--- a/components/OpenLoan/OpenLoanView.tsx
+++ b/components/OpenLoan/OpenLoanView.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect,  Dispatch } from 'react'
 import { Token } from '../Tokens'
 import { CollateralType } from './CollateralType'
 import SelectCollateralModal from './SelectCollateralModal'
-import { useDisclosure } from "@chakra-ui/hooks"
 import { FieldValues, useForm } from 'react-hook-form'
 import {
     Box,
@@ -68,20 +67,13 @@ const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: O
         validate()
     }, [token0, token1])
 
-    const { 
-        isOpen: isOpenSelectCollateral, 
-        onOpen: onOpenSelectCollateral, 
-        onClose: onCloseSelectCollateral
-    } = useDisclosure()
-
-    const handleCollateralSelected = (type: CollateralType) => {
-        console.log("selected collateral type", CollateralType[type])
-        setCollateralType(type)
-        setCollateralButtonText(getCollateralTypeButtonText(type))
-        setShowToken1(type == CollateralType.Both)
-        onCloseSelectCollateral()
-        validate()
-    }
+    useEffect(() => {
+      setIsOpen(false)
+      console.log("selected collateral type", CollateralType[collateralType])
+      setCollateralButtonText(getCollateralTypeButtonText(collateralType))
+      setShowToken1(collateralType == CollateralType.Both)
+      validate()
+    }, [collateralType])
 
     function getCollateralTypeButtonText(collateralType: CollateralType) {
         switch(collateralType) {
@@ -210,15 +202,15 @@ const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: O
                                 </NumberInput>
                                 <Container display='inline-flex' p='0' m='0'>
                                     <FormLabel variant='openLoanFit' pr='20px' m='0'>Your Collateral</FormLabel>
-                                    <Button variant='select' size='tiny' h='20px' rightIcon={<ChevronDownIcon />} onClick={onOpenSelectCollateral}>
+                                    <Button variant='select' size='tiny' h='20px' rightIcon={<ChevronDownIcon />} onClick={() => setIsOpen(true)}>
                                         <Text ml='4px'>{collateralButtonText}</Text>
                                     </Button>
                                     <SelectCollateralModal 
                                         token0={token0} 
                                         token1={token1} 
-                                        handleCollateralSelected={handleCollateralSelected} 
-                                        isOpen={isOpenSelectCollateral} 
-                                        onClose={onCloseSelectCollateral}
+                                        isOpen={isOpen} 
+                                        setIsOpen={setIsOpen}
+                                        setCollateralType={setCollateralType} 
                                     />
                                 </Container>
                                 <NumberInput 

--- a/components/OpenLoan/OpenLoanView.tsx
+++ b/components/OpenLoan/OpenLoanView.tsx
@@ -5,8 +5,6 @@ import { CollateralType } from './CollateralType'
 import SelectCollateralModal from './SelectCollateralModal'
 import { useDisclosure } from "@chakra-ui/hooks"
 import { FieldValues, useForm } from 'react-hook-form'
-import TokenSelectorModal from '../../components/TokenSelectorModal'
-import Image from 'next/image'
 import {
     Box,
     Container,
@@ -26,6 +24,7 @@ import {
 import {
     ChevronDownIcon
 } from '@chakra-ui/icons'
+import PairsSelector from '../PairsSelector'
 
 const style = {
     wrapper: "w-screen flex justify-center items-center",
@@ -53,7 +52,6 @@ type OpenLoanProps = {
 }
 
 const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: OpenLoanProps) => {
-    const [tokenNumber, setTokenNumber] = useState<number>(0)
     const [collateralType, setCollateralType] = useState<CollateralType>(CollateralType.None)
     const [collateralButtonText, setCollateralButtonText] = useState<string>("Select collateral type")
     const [confirmVariant, setConfirmVariant] = useState<string>("confirmGrey")
@@ -83,11 +81,6 @@ const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: O
         setShowToken1(type == CollateralType.Both)
         onCloseSelectCollateral()
         validate()
-    }
-
-    function onOpenToken(tokenNumber: number) {
-        setTokenNumber(tokenNumber)
-        setIsOpen(true)
     }
 
     function getCollateralTypeButtonText(collateralType: CollateralType) {
@@ -186,44 +179,7 @@ const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: O
                         <FormControl p='10px 15px 0px 15px' boxShadow='lg'>
                             <VStack>
                                 <Heading color={'#e2e8f0'} marginBottom={'25px'}>Open Your Loan</Heading>
-                                <FormLabel variant='openLoan'>Select a Token Pair</FormLabel>
-                                <Container display='inline-block'>
-                                    <Container w='50%' display='inline-grid' >
-                                        <div className={style.tokenSelectorContainer}>
-                                            <div className={style.tokenSelectorContent} onClick={() => onOpenToken(0)} >
-                                                <div className={style.tokenSelectorIcon}>
-                                                    <Image src={token0.imgPath} alt="token logo" width={32} height={32}/>
-                                                </div>
-                                                <div className={style.tokenSelectorTicker}>{token0.symbol}</div>
-                                                <ChevronDownIcon className={style.dropdownArrow}/>
-                                            </div>
-                                        </div>
-                                    </Container>
-                                    <Container w='50%' display='inline-grid' >
-                                        {isTokenEmpty(token1) 
-                                            ? (
-                                                <div className={style.nonSelectedTokenContainer}>
-                                                    <div className={style.nonSelectedTokenContent} onClick={() => onOpenToken(1)} >
-                                                        <div className={style.tokenSelectorIcon}>
-                                                            <Image src={token0.imgPath} width={0} height={32}/>
-                                                        </div>
-                                                        Select Token
-                                                    </div>
-                                                </div>
-                                            ) : (
-                                                <div className={style.tokenSelectorContainer}>
-                                                    <div className={style.tokenSelectorContent} onClick={() => onOpenToken(1)} >
-                                                        <div className={style.tokenSelectorIcon}>
-                                                            <Image src={token1.imgPath} alt="token logo" width={32} height={32}/>
-                                                        </div>
-                                                        <div className={style.tokenSelectorTicker}>{token1.symbol}</div>
-                                                        <ChevronDownIcon className={style.dropdownArrow}/>
-                                                    </div>
-                                                </div>
-                                            )
-                                        }
-                                    </Container>
-                                </Container>
+                                <PairsSelector token0={token0} token1={token1} setToken0={setToken0} setToken1={setToken1} />
                                 <Container textAlign='center'>
                                     <ButtonGroup variant='loanInfo' display='inline-block' size='tiny' >
                                         <Button leftIcon={<FaInfoCircle />}>
@@ -301,15 +257,6 @@ const OpenLoanView = ({openLoanHandler, token0, token1, setToken0, setToken1}: O
                     </form>
                 </Box >
             </Container>
-            <TokenSelectorModal
-                isOpen={isOpen}
-                setIsOpen={setIsOpen}
-                setTokenSelected={
-                tokenNumber === 0
-                ? setToken0
-                : setToken1
-                }
-            />
         </>
     )
 }

--- a/components/OpenLoan/SelectCollateralModal.tsx
+++ b/components/OpenLoan/SelectCollateralModal.tsx
@@ -1,60 +1,98 @@
-import * as React from 'react';
+import { Dispatch, SetStateAction, ReactElement, Fragment, useRef } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { XIcon } from '@heroicons/react/solid'
+import { CollateralType } from './CollateralType'
 import { Token } from '../Tokens'
-import { CollateralType } from './CollateralType';
 
-import {
-    Box,
-    Container,
-    FormControl,
-    Heading,
-    List,
-    ListItem,
-    Modal,
-    ModalOverlay,
-    ModalContent,
-    ModalHeader,
-    ModalBody,
-    ModalCloseButton,
-} from '@chakra-ui/react';
-
-interface SelectCollateralProps {
-    token0: Token;
-    token1: Token;
-    handleCollateralSelected: (type: CollateralType) => any;
-    isOpen: boolean;
-    onClose: () => void;
+const style = {
+  modalWrapper: "relative z-50",
+  modalOverlay: "fixed inset-0 bg-black/50 flex items-center justify-center p-4",
+  modal: "bg-gray-800 rounded-xl max-w-sm max-h-sm p-8 flex flex-col text-white drop-shadow-lg",
+  headingContainer: "flex",
+  closeIcon: "w-7 h-7 ml-auto cursor-pointer",
+  modalTitle: "font-semibold text-xl",
+  headingBreak: "mt-2 opacity-10",
+  tokensContainer: "mt-4 space-y-1 w-64",
+  tokenContainer: "flex text-md hover:bg-gray-700 rounded-lg p-3 cursor-pointer",
+  tokenImg: "w-7 h-7",
+  tokenSymbol: "ml-3 font-semibold",
+  tokenBalance: "ml-auto",
+  modalButton: "border-black border-solid border rounded mx-2 mt-8 py-1 px-2",
 }
 
-const SelectCollateralModal: React.FC<SelectCollateralProps> = (props) => {
-    return (
-        <Modal isOpen={props.isOpen} onClose={props.onClose}>
-            <ModalOverlay />
-            <ModalContent  borderRadius={'2xl'} bg={'#1d2c52'} boxShadow='dark-lg'>
-                <ModalHeader color={'#e2e8f0'} >Select Collateral Type</ModalHeader>
-                <ModalCloseButton color={'#e2e8f0'} />
-                <ModalBody>
-                        <FormControl>
-                            <List color={'#e2e8f0'} fontSize={'md'} fontWeight={'semibold'} cursor="pointer"
-                            >
-                                <ListItem key={CollateralType.LPToken} display='flex' p={1} onClick={() => props.handleCollateralSelected(CollateralType.LPToken)}> 
-                                    Liquidity Pool Tokens
-                                </ListItem>
-                                <ListItem key={CollateralType.Token0} display='flex' p={1} onClick={() => props.handleCollateralSelected(CollateralType.Token0)}> 
-                                    {props.token0.symbol} Token
-                                </ListItem>
-                                <ListItem key={CollateralType.Token1} display='flex' p={1} onClick={() => props.handleCollateralSelected(CollateralType.Token1)}> 
-                                    {props.token1.symbol} Token
-                                </ListItem>
-                                <ListItem key={CollateralType.Both} display='flex' p={1} onClick={() => props.handleCollateralSelected(CollateralType.Both)}> 
-                                    Both Tokens
-                                </ListItem>
+type ModalProps = {
+  token0: Token
+  token1: Token
+  isOpen: boolean
+  setIsOpen: Dispatch<SetStateAction<boolean>>
+  setCollateralType: Dispatch<SetStateAction<CollateralType>>
+}
 
-                            </List>
-                        </FormControl>
-                </ModalBody>
-            </ModalContent>
-        </Modal>
-    )
+const SelectCollateralModal = ({ 
+  token0, 
+  token1, 
+  isOpen, 
+  setIsOpen, 
+  setCollateralType }: ModalProps): ReactElement => {
+  // headlessUI requires at LEAST one focusable element
+  const closeIconRef = useRef(null)
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as={"div"} onClose={() => setIsOpen(false)}
+      className={style.modalWrapper}
+      initialFocus={closeIconRef}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-500"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+          >
+          <div className={style.modalOverlay}>
+            <Dialog.Panel className={style.modal}>
+              <div className={style.headingContainer}>
+                <Dialog.Title className={style.modalTitle}>
+                  Select Collateral Type
+                </Dialog.Title>
+                <XIcon
+                  className={style.closeIcon}
+                  onClick={() => setIsOpen(false)}
+                  ref={closeIconRef}
+                  />
+              </div>
+              <hr className={style.headingBreak}></hr>
+              <div className={style.tokensContainer}>
+                <div
+                  className={style.tokenContainer}
+                  onClick={() => setCollateralType(CollateralType.LPToken)}
+                  > Liquidity Pool Tokens
+                </div>
+                <div
+                  className={style.tokenContainer}
+                  onClick={() => setCollateralType(CollateralType.Token0)}
+                  > {token0.symbol} Token
+                </div>
+                <div
+                  className={style.tokenContainer}
+                  onClick={() => setCollateralType(CollateralType.Token1)}
+                  > {token1.symbol} Token
+                </div>
+                <div
+                  className={style.tokenContainer}
+                  onClick={() => setCollateralType(CollateralType.Both)}
+                  > Both Tokens
+                </div>
+              </div>
+            </Dialog.Panel>
+          </div>
+        </Transition.Child>
+      </Dialog>
+    </Transition>
+  )
 }
 
 export default SelectCollateralModal

--- a/components/PairsSelector.tsx
+++ b/components/PairsSelector.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { useState, Dispatch } from 'react'
+import { Token } from './Tokens'
+import TokenSelectorModal from './TokenSelectorModal'
+import Image from 'next/image'
+import { ChevronDownIcon } from '@heroicons/react/solid'
+
+const style = {
+  header: "w-full font-semibold text-gray-200",
+  pairContainer: "inline-flex w-full ",
+  tokenSelectorContainer: "px-6 text-gray-200 w-1/2",
+  nonSelectedTokenContent: "flex justify-center items-center bg-blue-500 rounded-2xl text-xl font-medium cursor-pointer p-2 mt-[-0.2rem] shadow-lg shadow-blue-500/30 hover:bg-blue-600 hover:shadow-blue-600/30",
+  tokenSelectorContent: "flex justify-between items-center bg-gray-700 rounded-2xl text-xl font-medium cursor-pointer p-2 mt-[-0.2rem] shadow-lg shadow-gray-700/30 hover:bg-gray-900 hover:shadow-gray-900/30",
+  tokenSelectorIcon: "flex items-center",
+  tokenSelectorTicker: "mx-2",
+  dropdownArrow: "w-12 h-8",
+}
+
+type PairsSelectorProps = {
+  token0: Token
+  token1: Token
+  setToken0: Dispatch<React.SetStateAction<Token>>
+  setToken1: Dispatch<React.SetStateAction<Token>>
+}
+
+const PairsSelector = ({token0, token1, setToken0, setToken1}: PairsSelectorProps) => {
+    const [tokenNumber, setTokenNumber] = useState<number>(0)
+    const [isOpen, setIsOpen] = useState<boolean>(false)
+    
+    function onOpenToken(tokenNumber: number) {
+        setTokenNumber(tokenNumber)
+        setIsOpen(true)
+    }
+
+    function isTokenEmpty(tokenToCheck: Token): boolean {
+      return Object.values(tokenToCheck).every(tokenProp => tokenProp === "")
+    }
+
+    return (
+      <>
+        <div className={style.header}> Select a Token Pair</div>
+        <div className={style.pairContainer}>
+            <div className={style.tokenSelectorContainer}>
+                <div className={style.tokenSelectorContent} onClick={() => onOpenToken(0)} >
+                    <div className={style.tokenSelectorIcon}>
+                        <Image src={token0.imgPath} alt="token logo" width={32} height={32}/>
+                    </div>
+                    <div className={style.tokenSelectorTicker}>{token0.symbol}</div>
+                    <ChevronDownIcon className={style.dropdownArrow}/>
+                </div>
+            </div>
+            <div className={style.tokenSelectorContainer}>
+            {isTokenEmpty(token1) 
+                ? (
+                  <div className={style.nonSelectedTokenContent} onClick={() => onOpenToken(1)} >
+                      <div className={style.tokenSelectorIcon}>
+                          <Image src={token0.imgPath} width={0} height={32}/>
+                      </div>
+                      Select Token
+                  </div>
+                ) : (
+                  <div className={style.tokenSelectorContent} onClick={() => onOpenToken(1)} >
+                      <div className={style.tokenSelectorIcon}>
+                          <Image src={token1.imgPath} alt="token logo" width={32} height={32}/>
+                      </div>
+                      <div className={style.tokenSelectorTicker}>{token1.symbol}</div>
+                      <ChevronDownIcon className={style.dropdownArrow}/>
+                  </div>
+                )
+            }
+            </div>
+        </div>
+        <TokenSelectorModal
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            setTokenSelected={ tokenNumber === 0 ? setToken0 : setToken1 }
+        />
+      </>
+    )
+}
+
+export default PairsSelector


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9112273/177021674-c6e268a3-5ec6-440d-9a80-617da3e81e04.png)

Every operation we offer requires users to select a pair. This control allows that. The exception is Add liquidity, which is done that each input has a single token selector beside it.
Thanks @Pochetes or @dam417 