### PR TITLE
Get Latest Pool Data Query

### DIFF
--- a/.graphclient/index.ts
+++ b/.graphclient/index.ts
@@ -246,6 +246,8 @@ export type PoolData = {
   lpTokenBorrowed: Scalars['BigDecimal'];
   lpTokenBorrowedPlusInterest: Scalars['BigDecimal'];
   lpTokenTotal: Scalars['BigDecimal'];
+  lpInvariant: Scalars['BigDecimal'];
+  lpBorrowedInvariant: Scalars['BigDecimal'];
   borrowRate: Scalars['BigDecimal'];
   accFeeIndex: Scalars['BigDecimal'];
   lastFeeIndex: Scalars['BigDecimal'];
@@ -305,6 +307,22 @@ export type PoolData_filter = {
   lpTokenTotal_lte?: InputMaybe<Scalars['BigDecimal']>;
   lpTokenTotal_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   lpTokenTotal_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpInvariant?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_not?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_gt?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_lt?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_gte?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_lte?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpInvariant_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpBorrowedInvariant?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_not?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_gt?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_lt?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_gte?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_lte?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpBorrowedInvariant_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   borrowRate?: InputMaybe<Scalars['BigDecimal']>;
   borrowRate_not?: InputMaybe<Scalars['BigDecimal']>;
   borrowRate_gt?: InputMaybe<Scalars['BigDecimal']>;
@@ -349,6 +367,8 @@ export type PoolData_orderBy =
   | 'lpTokenBorrowed'
   | 'lpTokenBorrowedPlusInterest'
   | 'lpTokenTotal'
+  | 'lpInvariant'
+  | 'lpBorrowedInvariant'
   | 'borrowRate'
   | 'accFeeIndex'
   | 'lastFeeIndex'
@@ -919,6 +939,8 @@ export type PoolDataResolvers<ContextType = MeshContext, ParentType extends Reso
   lpTokenBorrowed?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
   lpTokenBorrowedPlusInterest?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
   lpTokenTotal?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
+  lpInvariant?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
+  lpBorrowedInvariant?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
   borrowRate?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
   accFeeIndex?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
   lastFeeIndex?: Resolver<ResolversTypes['BigDecimal'], ParentType, ContextType>;
@@ -1136,7 +1158,7 @@ export type LatestPoolDataQueryVariables = Exact<{
 }>;
 
 
-export type LatestPoolDataQuery = { poolDatas: Array<Pick<PoolData, 'id' | 'address' | 'tokenBalances' | 'lpTokenBalance' | 'lpTokenBorrowed' | 'lpTokenBorrowedPlusInterest' | 'lpTokenTotal' | 'accFeeIndex' | 'lastBlockNumber' | 'borrowRate' | 'lastFeeIndex'>> };
+export type LatestPoolDataQuery = { poolDatas: Array<Pick<PoolData, 'id' | 'address' | 'tokenBalances' | 'lpTokenBalance' | 'lpTokenBorrowed' | 'lpTokenBorrowedPlusInterest' | 'lpTokenTotal' | 'lpInvariant' | 'lpBorrowedInvariant' | 'accFeeIndex' | 'lastBlockNumber' | 'borrowRate' | 'lastFeeIndex'>> };
 
 
 export const PoolsDocument = gql`
@@ -1166,6 +1188,8 @@ export const LatestPoolDataDocument = gql`
     lpTokenBorrowed
     lpTokenBorrowedPlusInterest
     lpTokenTotal
+    lpInvariant
+    lpBorrowedInvariant
     accFeeIndex
     lastBlockNumber
     borrowRate

--- a/.graphclient/schema.graphql
+++ b/.graphclient/schema.graphql
@@ -225,6 +225,8 @@ type PoolData {
   lpTokenBorrowed: BigDecimal!
   lpTokenBorrowedPlusInterest: BigDecimal!
   lpTokenTotal: BigDecimal!
+  lpInvariant: BigDecimal!
+  lpBorrowedInvariant: BigDecimal!
   borrowRate: BigDecimal!
   accFeeIndex: BigDecimal!
   lastFeeIndex: BigDecimal!
@@ -284,6 +286,22 @@ input PoolData_filter {
   lpTokenTotal_lte: BigDecimal
   lpTokenTotal_in: [BigDecimal!]
   lpTokenTotal_not_in: [BigDecimal!]
+  lpInvariant: BigDecimal
+  lpInvariant_not: BigDecimal
+  lpInvariant_gt: BigDecimal
+  lpInvariant_lt: BigDecimal
+  lpInvariant_gte: BigDecimal
+  lpInvariant_lte: BigDecimal
+  lpInvariant_in: [BigDecimal!]
+  lpInvariant_not_in: [BigDecimal!]
+  lpBorrowedInvariant: BigDecimal
+  lpBorrowedInvariant_not: BigDecimal
+  lpBorrowedInvariant_gt: BigDecimal
+  lpBorrowedInvariant_lt: BigDecimal
+  lpBorrowedInvariant_gte: BigDecimal
+  lpBorrowedInvariant_lte: BigDecimal
+  lpBorrowedInvariant_in: [BigDecimal!]
+  lpBorrowedInvariant_not_in: [BigDecimal!]
   borrowRate: BigDecimal
   borrowRate_not: BigDecimal
   borrowRate_gt: BigDecimal
@@ -328,6 +346,8 @@ enum PoolData_orderBy {
   lpTokenBorrowed
   lpTokenBorrowedPlusInterest
   lpTokenTotal
+  lpInvariant
+  lpBorrowedInvariant
   borrowRate
   accFeeIndex
   lastFeeIndex

--- a/.graphclient/sources/GammaSwap/introspectionSchema.ts
+++ b/.graphclient/sources/GammaSwap/introspectionSchema.ts
@@ -3126,6 +3126,44 @@ const schemaAST = {
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
+            "value": "lpInvariant"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BigDecimal"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BigDecimal"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
             "value": "borrowRate"
           },
           "arguments": [],
@@ -4101,6 +4139,270 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "lpInvariant"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigDecimal"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigDecimal"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigDecimal"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigDecimal"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigDecimal"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "borrowRate"
           },
           "type": {
@@ -4708,6 +5010,22 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "lpTokenTotal"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpInvariant"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lpBorrowedInvariant"
           },
           "directives": []
         },

--- a/.graphclient/sources/GammaSwap/schema.graphql
+++ b/.graphclient/sources/GammaSwap/schema.graphql
@@ -225,6 +225,8 @@ type PoolData {
   lpTokenBorrowed: BigDecimal!
   lpTokenBorrowedPlusInterest: BigDecimal!
   lpTokenTotal: BigDecimal!
+  lpInvariant: BigDecimal!
+  lpBorrowedInvariant: BigDecimal!
   borrowRate: BigDecimal!
   accFeeIndex: BigDecimal!
   lastFeeIndex: BigDecimal!
@@ -284,6 +286,22 @@ input PoolData_filter {
   lpTokenTotal_lte: BigDecimal
   lpTokenTotal_in: [BigDecimal!]
   lpTokenTotal_not_in: [BigDecimal!]
+  lpInvariant: BigDecimal
+  lpInvariant_not: BigDecimal
+  lpInvariant_gt: BigDecimal
+  lpInvariant_lt: BigDecimal
+  lpInvariant_gte: BigDecimal
+  lpInvariant_lte: BigDecimal
+  lpInvariant_in: [BigDecimal!]
+  lpInvariant_not_in: [BigDecimal!]
+  lpBorrowedInvariant: BigDecimal
+  lpBorrowedInvariant_not: BigDecimal
+  lpBorrowedInvariant_gt: BigDecimal
+  lpBorrowedInvariant_lt: BigDecimal
+  lpBorrowedInvariant_gte: BigDecimal
+  lpBorrowedInvariant_lte: BigDecimal
+  lpBorrowedInvariant_in: [BigDecimal!]
+  lpBorrowedInvariant_not_in: [BigDecimal!]
   borrowRate: BigDecimal
   borrowRate_not: BigDecimal
   borrowRate_gt: BigDecimal
@@ -328,6 +346,8 @@ enum PoolData_orderBy {
   lpTokenBorrowed
   lpTokenBorrowedPlusInterest
   lpTokenTotal
+  lpInvariant
+  lpBorrowedInvariant
   borrowRate
   accFeeIndex
   lastFeeIndex

--- a/.graphclient/sources/GammaSwap/types.ts
+++ b/.graphclient/sources/GammaSwap/types.ts
@@ -225,6 +225,8 @@ export type PoolData = {
   lpTokenBorrowed: Scalars['BigDecimal'];
   lpTokenBorrowedPlusInterest: Scalars['BigDecimal'];
   lpTokenTotal: Scalars['BigDecimal'];
+  lpInvariant: Scalars['BigDecimal'];
+  lpBorrowedInvariant: Scalars['BigDecimal'];
   borrowRate: Scalars['BigDecimal'];
   accFeeIndex: Scalars['BigDecimal'];
   lastFeeIndex: Scalars['BigDecimal'];
@@ -284,6 +286,22 @@ export type PoolData_filter = {
   lpTokenTotal_lte?: InputMaybe<Scalars['BigDecimal']>;
   lpTokenTotal_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   lpTokenTotal_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpInvariant?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_not?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_gt?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_lt?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_gte?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_lte?: InputMaybe<Scalars['BigDecimal']>;
+  lpInvariant_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpInvariant_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpBorrowedInvariant?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_not?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_gt?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_lt?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_gte?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_lte?: InputMaybe<Scalars['BigDecimal']>;
+  lpBorrowedInvariant_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
+  lpBorrowedInvariant_not_in?: InputMaybe<Array<Scalars['BigDecimal']>>;
   borrowRate?: InputMaybe<Scalars['BigDecimal']>;
   borrowRate_not?: InputMaybe<Scalars['BigDecimal']>;
   borrowRate_gt?: InputMaybe<Scalars['BigDecimal']>;
@@ -328,6 +346,8 @@ export type PoolData_orderBy =
   | 'lpTokenBorrowed'
   | 'lpTokenBorrowedPlusInterest'
   | 'lpTokenTotal'
+  | 'lpInvariant'
+  | 'lpBorrowedInvariant'
   | 'borrowRate'
   | 'accFeeIndex'
   | 'lastFeeIndex'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "clean": "rm -rf ./.graphclient",
-    "graphclient-build": "yarn clean && graphclient build",
+    "graphclient-build": "graphclient build",
     "build": "next build",
     "start": "next start"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "clean": "rm -rf ./.graphclient",
-    "graphclient-build": "graphclient build",
+    "graphclient-build": "yarn clean && graphclient build",
     "build": "next build",
     "start": "next start"
   },

--- a/pages/pools/main.tsx
+++ b/pages/pools/main.tsx
@@ -3,11 +3,14 @@ import { useState } from "react"
 import Image from "next/image"
 import { InformationCircleIcon } from "@heroicons/react/outline"
 import { ArrowUpIcon, ArrowDownIcon } from "@heroicons/react/outline"
-import { PoolData } from "../../src/components/Pools/PoolTableRow"
+import { PoolData } from "../../.graphclient"
 import { usePoolsHandler } from "../../src/hooks/usePoolsHandler"
 import { PoolsOverviewTable } from "../../src/components/Pools/PoolsOverviewTable"
 
 const Pools: NextPage = () => {
+  const { pools, latestPoolsData } = usePoolsHandler()
+  const [selectedPoolData, setSelectedPoolData] = useState<PoolData>()
+
   const style = {
     wrapper: "w-full h-full flex justify-center text-neutrals-100",
     container: "flex flex-col space-y-10 mx-auto mt-4",
@@ -25,9 +28,6 @@ const Pools: NextPage = () => {
     arrow: "w-4 h-4",
     poolStatChangeNumber: "text-secondary-jungleGreen",
   }
-
-  const { poolsData } = usePoolsHandler()
-  const [selectedPoolData, setSelectedPoolData] = useState<PoolData>()
 
   const poolStats = [
     {

--- a/src/hooks/usePoolsHandler.tsx
+++ b/src/hooks/usePoolsHandler.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { notifyError } from './useNotification'
 import { ExecutionResult } from 'graphql'
 import { PoolsDocument, Pool, PoolsQuery, LatestPoolDataDocument, execute, PoolData } from '../../.graphclient'
@@ -7,44 +7,47 @@ export const usePoolsHandler = () => {
   const [pools, setPools] = useState<ExecutionResult<PoolsQuery>>()
   const [latestPoolsData, setLatestPoolsData]  = useState<Array<PoolData>>([])
   
-  useEffect(() => {
-    const fetchPoolsData = async () => {
-      const res = await execute(PoolsDocument, {})
-      if (res?.data) {
-        setPools(res.data.pools)
-      } else {
-        console.log("NO RESPONSE")
+  // fetches all pool entities
+  const fetchPoolsData = useCallback(async () => {
+    const res = await execute(PoolsDocument, {})
+    if (res?.data) {
+      setPools(res.data.pools)
+    } else {
+      console.log("NO RESPONSE")
+    }
+  }, [])
+  
+  // fetches pool's latest data by pool address
+  const fetchLatestPoolData = async (address: string): Promise<PoolData | number> => {
+    const res = await execute(LatestPoolDataDocument, { address })
+    if (res?.data.poolDatas[0]) {
+      return res.data.poolDatas[0]
+    }
+  
+    return 0
+  }
+  
+  // iterates through all pool addresses and fetches latest pool data for it
+  const fetchLatestPoolsData = useCallback(async (pools: Array<Pool>) => {
+    const newPoolsData: Array<PoolData> = []
+
+    for (const pool of pools) {
+      const latestPoolData: PoolData | number = await fetchLatestPoolData(pool.address)
+      if (latestPoolData != 0) {
+        newPoolsData.push(latestPoolData as PoolData)
       }
     }
     
-    fetchPoolsData()
+    setLatestPoolsData(newPoolsData)
   }, [])
   
   useEffect(() => {
-    const fetchLatestPoolData = async (address: string): Promise<PoolData | number> => {
-      const res = await execute(LatestPoolDataDocument, { address })
-      if (res?.data.poolDatas[0]) {
-        return res.data.poolDatas[0]
-      }
+    fetchPoolsData()
+  }, [fetchPoolsData])
 
-      return 0
-    }
-
-    const fetchLatestPoolsData = async (pools: Array<Pool>) => {
-      // query latest pool data for each addr
-      // push to latestPoolsData
-      pools?.forEach(async pool => {
-        const latestPoolData: PoolData | number = await fetchLatestPoolData(pool.address)
-        if (latestPoolData != 0) {
-          const newPoolsData = [...latestPoolsData]
-          newPoolsData.push(latestPoolData as PoolData)
-          setLatestPoolsData(newPoolsData)
-        }
-      })
-    }
-    
-    fetchLatestPoolsData(pools as Array<Pool>)
-  }, [])
-
+  useEffect(() => {
+    if (pools) fetchLatestPoolsData(pools as Array<Pool>)
+  }, [pools])
+  
   return { pools, latestPoolsData }
 }

--- a/src/hooks/usePoolsHandler.tsx
+++ b/src/hooks/usePoolsHandler.tsx
@@ -1,21 +1,50 @@
 import { useEffect, useState } from 'react'
 import { notifyError } from './useNotification'
-import { PoolsQueryDocument, PoolsQueryQuery, execute } from '../../.graphclient'
+import { ExecutionResult } from 'graphql'
+import { PoolsDocument, Pool, PoolsQuery, LatestPoolDataDocument, execute, PoolData } from '../../.graphclient'
 
 export const usePoolsHandler = () => {
-  const [poolsData, setPoolsData] = useState<PoolsQueryQuery>()
+  const [pools, setPools] = useState<ExecutionResult<PoolsQuery>>()
+  const [latestPoolsData, setLatestPoolsData]  = useState<Array<PoolData>>([])
   
   useEffect(() => {
     const fetchPoolsData = async () => {
-      const res = await execute(PoolsQueryDocument, {})
+      const res = await execute(PoolsDocument, {})
       if (res?.data) {
-        setPoolsData(res?.data)
+        setPools(res.data.pools)
       } else {
         console.log("NO RESPONSE")
       }
     }
+    
     fetchPoolsData()
   }, [])
+  
+  useEffect(() => {
+    const fetchLatestPoolData = async (address: string): Promise<PoolData | number> => {
+      const res = await execute(LatestPoolDataDocument, { address })
+      if (res?.data.poolDatas[0]) {
+        return res.data.poolDatas[0]
+      }
 
-  return { poolsData }
+      return 0
+    }
+
+    const fetchLatestPoolsData = async (pools: Array<Pool>) => {
+      // query latest pool data for each addr
+      // push to latestPoolsData
+      pools?.forEach(async pool => {
+        const latestPoolData: PoolData | number = await fetchLatestPoolData(pool.address)
+        if (latestPoolData != 0) {
+          const newPoolsData = [...latestPoolsData]
+          newPoolsData.push(latestPoolData as PoolData)
+          setLatestPoolsData(newPoolsData)
+        }
+      })
+    }
+    
+    fetchLatestPoolsData(pools as Array<Pool>)
+  }, [])
+
+  return { pools, latestPoolsData }
 }

--- a/src/queries/pools.graphql
+++ b/src/queries/pools.graphql
@@ -25,6 +25,8 @@ query LatestPoolData($address: Bytes) {
     lpTokenBorrowed
     lpTokenBorrowedPlusInterest
     lpTokenTotal
+    lpInvariant
+    lpBorrowedInvariant
     accFeeIndex
     lastBlockNumber
     borrowRate

--- a/src/queries/pools.graphql
+++ b/src/queries/pools.graphql
@@ -1,5 +1,5 @@
 # queries basic info about each pool created
-query PoolsQuery {
+query Pools {
   pools {
     id
     address
@@ -7,5 +7,27 @@ query PoolsQuery {
     protocolId
     protocol
     count
+  }
+}
+
+# queries latest data for pool
+query LatestPoolData($address: Bytes) {
+  poolDatas(
+    where: {address: $address}
+    orderBy: lastBlockNumber
+    first: 1
+    orderDirection: desc
+  ) {
+    id
+    address
+    tokenBalances
+    lpTokenBalance
+    lpTokenBorrowed
+    lpTokenBorrowedPlusInterest
+    lpTokenTotal
+    accFeeIndex
+    lastBlockNumber
+    borrowRate
+    lastFeeIndex
   }
 }


### PR DESCRIPTION
## Overview
- fetched latest pool data for each pool entity in the subgraph.
- reduced render count by leveraging `useCallback` when fetching for each pool and latest pool data
- generated new types (invariants) from the subgraph to the graphclient build


### Optimizations
As we have talked about before, the current subgraph architecture leads to high query latency in that we have to make two round trips (querying the pools entities for the pool addresses, and then the latest pool data for each). In later updates, we will optimize this by:

- adding and updating all the latest pool properties into the `Pool` entity so that we would only need to query the pools
- maintaining transaction data (rename `PoolData` to `Transaction`) for time series graphs or historical data we would need for the interface
    - this could be modularized further by having a `PoolSnapshot` entity that holds a `Transaction` object, which would help track any transaction that has been recorded.